### PR TITLE
Optimise median calculation by sorting on insert

### DIFF
--- a/pkg/bench/bench_test.go
+++ b/pkg/bench/bench_test.go
@@ -20,7 +20,7 @@ func TestGenerateResult(t *testing.T) {
 		},
 		{
 			name:  "sample case",
-			input: []time.Duration{time.Second, 2 * time.Second, 4 * time.Second, 1 * time.Second, 9 * time.Second},
+			input: []time.Duration{time.Second, 1 * time.Second, 2 * time.Second, 4 * time.Second, 9 * time.Second},
 			exp: Result{
 				NumQueries:          5,
 				TotalProcessingTime: 17 * time.Second,
@@ -32,7 +32,7 @@ func TestGenerateResult(t *testing.T) {
 		},
 		{
 			name:  "even observations",
-			input: []time.Duration{time.Second, 2 * time.Second, 4 * time.Second, 1 * time.Second, 9 * time.Second, 3 * time.Second},
+			input: []time.Duration{time.Second, 1 * time.Second, 2 * time.Second, 3 * time.Second, 4 * time.Second, 9 * time.Second},
 			exp: Result{
 				NumQueries:          6,
 				TotalProcessingTime: 20 * time.Second,
@@ -49,6 +49,44 @@ func TestGenerateResult(t *testing.T) {
 			got := generateResult(v.input)
 
 			testutil.Equals(t, v.exp, got)
+		})
+	}
+}
+
+func TestSortedAppend(t *testing.T) {
+	cases := []struct {
+		name   string
+		arr    []time.Duration
+		insert []time.Duration
+		exp    []time.Duration
+	}{
+		{
+			name:   "empty input, one insert",
+			arr:    []time.Duration{},
+			insert: []time.Duration{time.Second},
+			exp:    []time.Duration{time.Second},
+		},
+		{
+			name:   "empty input, multiple inserts",
+			arr:    []time.Duration{},
+			insert: []time.Duration{time.Second, 3 * time.Second, 2 * time.Second},
+			exp:    []time.Duration{time.Second, 2 * time.Second, 3 * time.Second},
+		},
+		{
+			name:   "non-empty input, multiple inserts",
+			arr:    []time.Duration{time.Second, 3 * time.Second, 4 * time.Second, 9 * time.Second},
+			insert: []time.Duration{time.Second, 7 * time.Second, 2 * time.Second},
+			exp:    []time.Duration{time.Second, time.Second, 2 * time.Second, 3 * time.Second, 4 * time.Second, 7 * time.Second, 9 * time.Second},
+		},
+	}
+
+	for _, v := range cases {
+		t.Run(v.name, func(t *testing.T) {
+			for _, d := range v.insert {
+				v.arr = sortedAppend(v.arr, d)
+			}
+
+			testutil.Equals(t, v.exp, v.arr)
 		})
 	}
 }


### PR DESCRIPTION
Instead of sorting after collecting all observations, we sort as soon as we insert the observation in the array. Apart from lowering the average time complexity, we also benefit from the fact that the observations coming from network calls and sorting as soon as we get the value is a better approach the sorting after we get all the values.